### PR TITLE
Minimal change in documentation

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -18,7 +18,7 @@ To enable metrics first setup maven to include this as a dependency
 ----
 <dependency>
   <groupId>io.vertx</groupId>
-  <artifactId>vertx-metrics</artifactId>
+  <artifactId>vertx-dropwizard-metrics</artifactId>
   <version>${vertx.metrics.version}</version>
 </dependency>
 ----
@@ -93,7 +93,7 @@ println(metrics)
 ----
 
 NOTE: For details on the actual contents of the data (the actual metric) represented by the `link:../../vertx-core/groovy/groovydoc/io/vertx/groovy/core/json/JsonObject.html[JsonObject]`
-consult the implementation documentation like https://github.com/vert-x3/vertx-metrics[vertx-metrics]
+consult the implementation documentation like https://github.com/vert-x3/vertx-dropwizard-metrics[vertx-dropwizard-metrics]
 
 Often it is desired that you only want to capture specific metrics for a particular component, like an http server
 without having to know the details of the naming scheme of every metric (something which is left to the implementers of the SPI).

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -18,7 +18,7 @@ To enable metrics first setup maven to include this as a dependency
 ----
 <dependency>
   <groupId>io.vertx</groupId>
-  <artifactId>vertx-metrics</artifactId>
+  <artifactId>vertx-dropwizard-metrics</artifactId>
   <version>${vertx.metrics.version}</version>
 </dependency>
 ----
@@ -81,7 +81,7 @@ System.out.println(metrics);
 ----
 
 NOTE: For details on the actual contents of the data (the actual metric) represented by the `link:../../apidocs/io/vertx/core/json/JsonObject.html[JsonObject]`
-consult the implementation documentation like https://github.com/vert-x3/vertx-metrics[vertx-metrics]
+consult the implementation documentation like https://github.com/vert-x3/vertx-dropwizard-metrics[vertx-dropwizard-metrics]
 
 Often it is desired that you only want to capture specific metrics for a particular component, like an http server
 without having to know the details of the naming scheme of every metric (something which is left to the implementers of the SPI).

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -18,7 +18,7 @@ To enable metrics first setup maven to include this as a dependency
 ----
 <dependency>
   <groupId>io.vertx</groupId>
-  <artifactId>vertx-metrics</artifactId>
+  <artifactId>vertx-dropwizard-metrics</artifactId>
   <version>${vertx.metrics.version}</version>
 </dependency>
 ----
@@ -93,7 +93,7 @@ console.log(metrics);
 ----
 
 NOTE: For details on the actual contents of the data (the actual metric) represented by the `link:../../vertx-core/js/jsdoc/json_object-JsonObject.html[JsonObject]`
-consult the implementation documentation like https://github.com/vert-x3/vertx-metrics[vertx-metrics]
+consult the implementation documentation like https://github.com/vert-x3/vertx-dropwizard-metrics[vertx-dropwizard-metrics]
 
 Often it is desired that you only want to capture specific metrics for a particular component, like an http server
 without having to know the details of the naming scheme of every metric (something which is left to the implementers of the SPI).


### PR DESCRIPTION
This pull request is just for adjusting the name of the project from `vertx-metrics` to the current one, `vertx-dropwizard-metrics` in links and maven references