### PR TITLE
Feature/extend options construction

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -96,31 +96,20 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     jmxEnabled = json.getBoolean("jmxEnabled", DEFAULT_JMX_ENABLED);
     jmxDomain = json.getString("jmxDomain");
 
-    monitoredEventBusHandlers = new ArrayList<>();
-    monitoredHttpServerUris = new ArrayList<>();
-    monitoredHttpClientUris = new ArrayList<>();
+    monitoredEventBusHandlers = loadMonitored("monitoredHandlers", json);
+    monitoredHttpServerUris = loadMonitored("monitoredServerUris", json);
+    monitoredHttpClientUris = loadMonitored("monitoredClientUris", json);
+  }
 
-    JsonArray handlerAddressesArray = json.getJsonArray("monitoredHandlers");
-    if (handlerAddressesArray != null) {
-      for (Object o : handlerAddressesArray) {
-        monitoredEventBusHandlers.add(new Match((JsonObject) o));
-      }
-    }
+  private List<Match> loadMonitored(String arrayField, JsonObject json) {
+    List<Match> list = new ArrayList<>();
 
-    JsonArray httpServerUris = json.getJsonArray("monitoredServerUris");
-    if (httpServerUris != null) {
-      for (Object o : httpServerUris) {
-        monitoredHttpServerUris.add(new Match((JsonObject) o));
-      }
-    }
+    JsonArray monitored = json.getJsonArray(arrayField, new JsonArray());
+    monitored.forEach(object -> {
+      if (object instanceof JsonObject) list.add(new Match((JsonObject) object));
+    });
 
-    JsonArray httpClientUris = json.getJsonArray("monitoredClientUris");
-    if (httpClientUris != null) {
-      for (Object o : httpClientUris) {
-        monitoredHttpClientUris.add(new Match((JsonObject) o));
-      }
-    }
-
+    return list;
   }
 
   /**

--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -81,6 +81,8 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     jmxEnabled = other.isJmxEnabled();
     jmxDomain = other.getJmxDomain();
     monitoredEventBusHandlers = new ArrayList<>(other.monitoredEventBusHandlers);
+    monitoredHttpServerUris = new ArrayList<>(other.monitoredHttpServerUris);
+    monitoredHttpClientUris = new ArrayList<>(other.monitoredHttpClientUris);
   }
 
   /**
@@ -93,13 +95,32 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     registryName = json.getString("registryName");
     jmxEnabled = json.getBoolean("jmxEnabled", DEFAULT_JMX_ENABLED);
     jmxDomain = json.getString("jmxDomain");
+
     monitoredEventBusHandlers = new ArrayList<>();
+    monitoredHttpServerUris = new ArrayList<>();
+    monitoredHttpClientUris = new ArrayList<>();
+
     JsonArray handlerAddressesArray = json.getJsonArray("monitoredHandlers");
     if (handlerAddressesArray != null) {
       for (Object o : handlerAddressesArray) {
         monitoredEventBusHandlers.add(new Match((JsonObject) o));
       }
     }
+
+    JsonArray httpServerUris = json.getJsonArray("monitoredServerUris");
+    if (httpServerUris != null) {
+      for (Object o : httpServerUris) {
+        monitoredHttpServerUris.add(new Match((JsonObject) o));
+      }
+    }
+
+    JsonArray httpClientUris = json.getJsonArray("monitoredClientUris");
+    if (httpClientUris != null) {
+      for (Object o : httpClientUris) {
+        monitoredHttpClientUris.add(new Match((JsonObject) o));
+      }
+    }
+
   }
 
   /**


### PR DESCRIPTION
Modified the JSON constructor for the Options so that server URIs and client URIs can also be included in there. 

This also fixes a bug where it wasn't possible to add server and client URIs unless the default constructor was used, due to the arraylists not being initialized.