### PR TITLE
Modify the JMXReporter so that the Throughput beans are dealt with as…

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/ThroughputMeter.java
+++ b/src/main/java/io/vertx/ext/dropwizard/ThroughputMeter.java
@@ -1,6 +1,5 @@
 package io.vertx.ext.dropwizard;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import io.vertx.ext.dropwizard.impl.InstantThroughput;
 
@@ -10,11 +9,10 @@ import io.vertx.ext.dropwizard.impl.InstantThroughput;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class ThroughputMeter extends Meter implements Gauge<Long> {
+public class ThroughputMeter extends Meter {
 
   private final InstantThroughput instantThroughput = new InstantThroughput();
 
-  @Override
   public Long getValue() {
     return instantThroughput.count();
   }

--- a/src/main/java/io/vertx/ext/dropwizard/ThroughputTimer.java
+++ b/src/main/java/io/vertx/ext/dropwizard/ThroughputTimer.java
@@ -1,6 +1,5 @@
 package io.vertx.ext.dropwizard;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import io.vertx.ext.dropwizard.impl.InstantThroughput;
@@ -13,11 +12,10 @@ import java.util.concurrent.TimeUnit;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class ThroughputTimer extends Timer implements Gauge<Long> {
+public class ThroughputTimer extends Timer {
 
   private final InstantThroughput instantThroughput = new InstantThroughput();
 
-  @Override
   public Long getValue() {
     return instantThroughput.count();
   }


### PR DESCRIPTION
Due to the way Codahale's code works, anything that implements `Gauge` will call `onGaugeAdded` within `JmxListener`. So this meant that `ThroughputTimer` and `ThroughputMeter` were only having the one value exposed in JMX.

I've changed those two so they no longer implement `Gauge`, and thus get treated as a `Timer` and `Meter` respectively. Then I created two new JMX objects for them, which extend `JmxTimer` and `JmxMeter`, so that the Instant Throughput number is visible.