### PR TITLE
Load Config From File

### DIFF
--- a/src/main/asciidoc/cheatsheet/DropwizardMetricsOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/DropwizardMetricsOptions.adoc
@@ -38,6 +38,12 @@ Add an monitored http server uri.+++
 |[[enabled]]`enabled`
 |`Boolean`
 |-
+|[[configFileName]]`configFileName`
+|`String`
+|+++
+Set the file name for a config file that contains options in JSON format, to be used to create a new options object.
+ The file will be looked for on the file system first and then on the classpath if it's not found.+++
+
 |[[monitoredHttpClientUris]]`monitoredHttpClientUris`
 |`Array of link:Match.html[Match]`
 |+++

--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -59,6 +59,7 @@ public class DropwizardMetricsOptions extends MetricsOptions {
   private List<Match> monitoredEventBusHandlers;
   private List<Match> monitoredHttpServerUris;
   private List<Match> monitoredHttpClientUris;
+  private String configFileName;
 
   /**
    * Default constructor
@@ -231,6 +232,25 @@ public class DropwizardMetricsOptions extends MetricsOptions {
   @Override
   public DropwizardMetricsOptions setEnabled(boolean enable) {
     return (DropwizardMetricsOptions) super.setEnabled(enable);
+  }
+
+  /**
+   * @return the file name for a config file to create an Options object from.
+   */
+  public String getConfigFileName() {
+    return configFileName;
+  }
+
+  /**
+   * Set the file name for a config file that contains options in JSON format, to be used to create a new options object.
+   * The file will be looked for on the file system first and then on the classpath if it's not found.
+   *
+   * @param configFileName the file name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DropwizardMetricsOptions setConfigFileName(String configFileName) {
+    this.configFileName = configFileName;
+    return this;
   }
 
   /**

--- a/src/test/java/io/vertx/ext/dropwizard/VertxMetricFactoryImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/VertxMetricFactoryImplTest.java
@@ -1,0 +1,114 @@
+package io.vertx.ext.dropwizard;
+
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.ext.dropwizard.impl.VertxMetricsFactoryImpl;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:john.warner@ef.com">John Warner</a>
+ */
+public class VertxMetricFactoryImplTest extends VertxTestBase {
+
+  private VertxMetrics metrics;
+
+  @After
+  public void after() throws Exception {
+    if (metrics != null) {
+      metrics.close();
+      metrics = null;
+    }
+  }
+
+  @Test
+  public void testLoadingFromFile() throws Exception {
+    String filePath = ClassLoader.getSystemResource("test_metrics_config.json").getFile();
+    DropwizardMetricsOptions dmo = new DropwizardMetricsOptions().setConfigFileName(filePath);
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
+
+    // Verify our jmx domain isn't there already, just in case.
+    assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
+
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    metrics = vmfi.metrics(vertx, vertxOptions);
+
+    List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
+
+    // If our file was loaded correctly, then our jmx domain will exist.
+    assertTrue(jmxDomains.contains("test-jmx-domain"));
+  }
+
+  @Test
+  public void testloadingFileFromClasspath() throws Exception {
+    String fileName = "test_metrics_config.json";
+    DropwizardMetricsOptions dmo = new DropwizardMetricsOptions().setConfigFileName(fileName);
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
+
+    // Verify our jmx domain isn't there already, just in case.
+    assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
+
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    metrics = vmfi.metrics(vertx, vertxOptions);
+
+    List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
+
+    // If our file was loaded correctly, then our jmx domain will exist.
+    assertTrue(jmxDomains.contains("test-jmx-domain"));
+  }
+
+  @Test
+  public void testLoadingWithJmxDisabled() throws Exception {
+    String filePath = ClassLoader.getSystemResource("test_metrics_config_jmx_disabled.json").getFile();
+    DropwizardMetricsOptions dmo = new DropwizardMetricsOptions().setConfigFileName(filePath);
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
+
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    metrics = vmfi.metrics(vertx, vertxOptions);
+
+    List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
+
+    // If our file was loaded correctly, then our jmx domain will exist.
+    assertFalse(jmxDomains.contains("test-jmx-domain"));
+  }
+
+  @Test
+  public void testWithNoConfigFile() throws Exception {
+    DropwizardMetricsOptions dmo = new DropwizardMetricsOptions()
+        .setJmxEnabled(true)
+        .setJmxDomain("non-file-jmx");
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
+
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    metrics = vmfi.metrics(vertx, vertxOptions);
+
+    List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
+
+    assertFalse(jmxDomains.contains("test-jmx-domain"));
+    assertTrue(jmxDomains.contains("non-file-jmx"));
+  }
+
+  @Test
+  public void testLoadingWithMissingFile() throws Exception {
+    String filePath = "/i/am/not/here/missingfile.json";
+
+    DropwizardMetricsOptions dmo = new DropwizardMetricsOptions()
+        .setJmxEnabled(true)
+        .setJmxDomain("non-file-jmx")
+        .setConfigFileName(filePath);
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
+
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    metrics = vmfi.metrics(vertx, vertxOptions);
+
+    List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
+
+    assertFalse(jmxDomains.contains("test-jmx-domain"));
+    assertTrue(jmxDomains.contains("non-file-jmx"));
+  }
+}

--- a/src/test/resources/test_metrics_config.json
+++ b/src/test/resources/test_metrics_config.json
@@ -1,0 +1,4 @@
+{
+  "jmxEnabled": true,
+  "jmxDomain": "test-jmx-domain"
+}

--- a/src/test/resources/test_metrics_config_jmx_disabled.json
+++ b/src/test/resources/test_metrics_config_jmx_disabled.json
@@ -1,0 +1,4 @@
+{
+  "jmxEnabled": false,
+  "jmxDomain": "test-jmx-domain"
+}


### PR DESCRIPTION
Added the ability to specify a metrics configuration file in the system property `vertx.metrics.options.file`. 

We need this because we use the vertx script to start applications and this change enables us to put in the metrics configuration we want.

I've added 3 tests and included a *test* dependency on Mockito for those tests.