### PR TITLE
Update index.adoc

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -533,10 +533,12 @@ so you can retrieve this registry and use according to your needs.
 
 [source,java]
 ----
-VertxOptions options = new VertxOptions().setMetricsOptions(
-  new MetricsServiceOptions().setEnabled(true).setRegistryName("the_name")
-);
-Vertx vertx = Vertx.vertxt(options);
+def vertx = Vertx.vertx([
+  metricsOptions:[
+    enabled:true,
+    registryName:"the_name"
+  ]
+])
 
 // Get the registry
 MetricRegistry registry = SharedMetricRegistries.getOrCreate("the_name");


### PR DESCRIPTION
Changed the code for Accessing Dropwizard Registry where it creates a new vertx instance so it now uses a Groovy map, matching the previous examples on the page.