### PR TITLE
Fixes #29 Intermittent failures in io.vertx.ext.dropwizard.MetricsTest.testMultiHttpClients

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -386,7 +386,7 @@ def vertx = Vertx.vertx([
       ],
       [
         value:"business-.*",
-        type:MatchType.REGEX
+        type:"REGEX"
       ]
     ]
   ]
@@ -431,7 +431,7 @@ def vertx = Vertx.vertx([
       ],
       [
         value:"/foo/.*",
-        type:MatchType.REGEX
+        type:"REGEX"
       ]
     ]
   ]

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -385,7 +385,7 @@ var vertx = Vertx.vertx({
       },
       {
         "value" : "business-.*",
-        "type" : 'REGEX'
+        "type" : "REGEX"
       }
     ]
   }
@@ -429,7 +429,7 @@ var vertx = Vertx.vertx({
       },
       {
         "value" : "/foo/.*",
-        "type" : 'REGEX'
+        "type" : "REGEX"
       }
     ]
   }

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -385,7 +385,7 @@ vertx = Vertx::Vertx.vertx({
       },
       {
         'value' => "business-.*",
-        'type' => :REGEX
+        'type' => "REGEX"
       }
     ]
   }
@@ -429,7 +429,7 @@ vertx = Vertx::Vertx.vertx({
       },
       {
         'value' => "/foo/.*",
-        'type' => :REGEX
+        'type' => "REGEX"
       }
     ]
   }

--- a/src/test/java/io/vertx/ext/dropwizard/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/MetricsTest.java
@@ -27,7 +27,6 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.buffer.Buffer;
@@ -54,8 +53,6 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.ext.dropwizard.impl.Helper;
 import io.vertx.test.core.RepeatRule;
 import io.vertx.test.core.TestUtils;
-import io.vertx.test.fakemetrics.FakeHttpClientMetrics;
-import io.vertx.test.fakemetrics.FakeMetricsBase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -68,9 +65,7 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -78,7 +73,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.vertx.test.core.TestUtils.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
@@ -1119,11 +1113,11 @@ public class MetricsTest extends MetricsTestBase {
     for (int i = 0;i < size;i++) {
       clients[i] = vertx.createHttpClient();
       HttpClientRequest req = clients[i].get(8080, "localhost", "/", resp -> {
-        responseLatch.countDown();
+        vertx.runOnContext(rlv -> responseLatch.countDown());
       });
       req.connectionHandler(conn -> {
         conn.closeHandler(v -> {
-          closedLatch.countDown();
+          vertx.runOnContext(clv -> closedLatch.countDown());
         });
       });
       req.end();


### PR DESCRIPTION
Update latches after the SPI callbacks are invoked.