### PR TITLE
Fixes #50 Use options field names when reading from JSON

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -120,10 +120,10 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     jmxEnabled = json.getBoolean("jmxEnabled", DEFAULT_JMX_ENABLED);
     jmxDomain = json.getString("jmxDomain");
     configPath = json.getString("configPath");
-    monitoredEventBusHandlers = loadMonitored("monitoredHandlers", json);
-    monitoredHttpServerUris = loadMonitored("monitoredServerUris", json);
-    monitoredHttpClientUris = loadMonitored("monitoredClientUris", json);
-    monitoredHttpClientEndpoints = loadMonitored("monitoredClientEndpoints", json);
+    monitoredEventBusHandlers = loadMonitored("monitoredEventBusHandlers", json);
+    monitoredHttpServerUris = loadMonitored("monitoredHttpServerUris", json);
+    monitoredHttpClientUris = loadMonitored("monitoredHttpClientUris", json);
+    monitoredHttpClientEndpoints = loadMonitored("monitoredHttpClientEndpoints", json);
   }
 
   private List<Match> loadMonitored(String arrayField, JsonObject json) {
@@ -192,7 +192,7 @@ public class DropwizardMetricsOptions extends MetricsOptions {
   /**
    * Set the JMX domain to use when JMX metrics are enabled.
    *
-   * @param jmxDomain  the JMX domain
+   * @param jmxDomain the JMX domain
    * @return a reference to this, so the API can be used fluently
    */
   public DropwizardMetricsOptions setJmxDomain(String jmxDomain) {

--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -19,6 +19,8 @@ package io.vertx.ext.dropwizard;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.metrics.MetricsOptions;
 
 import java.util.ArrayList;
@@ -32,6 +34,7 @@ import java.util.List;
  */
 @DataObject
 public class DropwizardMetricsOptions extends MetricsOptions {
+  private static final Logger log = LoggerFactory.getLogger(DropwizardMetricsOptions.class);
 
   /**
    * The default value of JMX enabled = false
@@ -120,10 +123,30 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     jmxEnabled = json.getBoolean("jmxEnabled", DEFAULT_JMX_ENABLED);
     jmxDomain = json.getString("jmxDomain");
     configPath = json.getString("configPath");
-    monitoredEventBusHandlers = loadMonitored("monitoredEventBusHandlers", json);
-    monitoredHttpServerUris = loadMonitored("monitoredHttpServerUris", json);
-    monitoredHttpClientUris = loadMonitored("monitoredHttpClientUris", json);
-    monitoredHttpClientEndpoints = loadMonitored("monitoredHttpClientEndpoints", json);
+    if (json.containsKey("monitoredHandlers") && !json.containsKey("monitoredEventBusHandlers")) {
+      log.warn("JSON config: monitoredHandlers field is deprecated, use monitoredEventBusHandlers instead");
+      monitoredEventBusHandlers = loadMonitored("monitoredHandlers", json);
+    } else {
+      monitoredEventBusHandlers = loadMonitored("monitoredEventBusHandlers", json);
+    }
+    if (json.containsKey("monitoredServerUris") && !json.containsKey("monitoredHttpServerUris")) {
+      log.warn("JSON config: monitoredServerUris field is deprecated, use monitoredHttpServerUris instead");
+      monitoredHttpServerUris = loadMonitored("monitoredServerUris", json);
+    } else {
+      monitoredHttpServerUris = loadMonitored("monitoredHttpServerUris", json);
+    }
+    if (json.containsKey("monitoredClientUris") && !json.containsKey("monitoredHttpClientUris")) {
+      log.warn("JSON config: monitoredClientUris field is deprecated, use monitoredHttpClientUris instead");
+      monitoredHttpClientUris = loadMonitored("monitoredClientUris", json);
+    } else {
+      monitoredHttpClientUris = loadMonitored("monitoredHttpClientUris", json);
+    }
+    if (json.containsKey("monitoredClientEndpoints") && !json.containsKey("monitoredHttpClientEndpoints")) {
+      log.warn("JSON config: monitoredClientEndpoints field is deprecated, use monitoredHttpClientEndpoints instead");
+      monitoredHttpClientEndpoints = loadMonitored("monitoredClientEndpoints", json);
+    } else {
+      monitoredHttpClientEndpoints = loadMonitored("monitoredHttpClientEndpoints", json);
+    }
   }
 
   private List<Match> loadMonitored(String arrayField, JsonObject json) {

--- a/src/test/java/io/vertx/ext/dropwizard/MetricsOptionsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/MetricsOptionsTest.java
@@ -92,11 +92,11 @@ public class MetricsOptionsTest extends VertxTestBase {
     String registryName = TestUtils.randomAlphaString(100);
     String configPath = TestUtils.randomAlphaString(100);
     options = new DropwizardMetricsOptions(new JsonObject().
-        put("enabled", metricsEnabled).
-        put("registryName", registryName).
-        put("jmxEnabled", jmxEnabled).
-        put("jmxDomain", jmxDomain).
-        put("configPath", configPath)
+      put("enabled", metricsEnabled).
+      put("registryName", registryName).
+      put("jmxEnabled", jmxEnabled).
+      put("jmxDomain", jmxDomain).
+      put("configPath", configPath)
     );
     assertEquals(metricsEnabled, options.isEnabled());
     assertEquals(registryName, options.getRegistryName());
@@ -107,26 +107,26 @@ public class MetricsOptionsTest extends VertxTestBase {
   @Test
   public void testFullJsonOptions() throws Exception {
 
-    JsonArray monitoredServerUris = new JsonArray()
-        .add(new JsonObject().put("value", "/test/server/1").put("type", "EQUALS"))
-        .add(new JsonObject().put("value", "^/server/test/2/.*").put("type", "REGEX"));
+    JsonArray monitoredHttpServerUris = new JsonArray()
+      .add(new JsonObject().put("value", "/test/server/1").put("type", "EQUALS"))
+      .add(new JsonObject().put("value", "^/server/test/2/.*").put("type", "REGEX"));
 
-    JsonArray monitoredClientUris = new JsonArray()
-        .add(new JsonObject().put("value", "/test/client/1").put("type", "EQUALS"))
-        .add(new JsonObject().put("value", "^/client/test/2/.*").put("type", "REGEX"));
+    JsonArray monitoredHttpClientUris = new JsonArray()
+      .add(new JsonObject().put("value", "/test/client/1").put("type", "EQUALS"))
+      .add(new JsonObject().put("value", "^/client/test/2/.*").put("type", "REGEX"));
 
-    JsonArray monitoredHandlers = new JsonArray()
-        .add(new JsonObject().put("value", "test.address.1").put("type", "EQUALS"))
-        .add(new JsonObject().put("value", "^test.2.*").put("type", "REGEX"));
+    JsonArray monitoredEventBusHandlers = new JsonArray()
+      .add(new JsonObject().put("value", "test.address.1").put("type", "EQUALS"))
+      .add(new JsonObject().put("value", "^test.2.*").put("type", "REGEX"));
 
     JsonObject config = new JsonObject()
-        .put("registryName", "testRegistry")
-        .put("jmxEnabled", true)
-        .put("jmxDomain", "testJmxDomain")
-        .put("monitoredServerUris", monitoredServerUris)
-        .put("monitoredClientUris", monitoredClientUris)
-        .put("monitoredHandlers", monitoredHandlers)
-        .put("configPath", "the_config_file");
+      .put("registryName", "testRegistry")
+      .put("jmxEnabled", true)
+      .put("jmxDomain", "testJmxDomain")
+      .put("monitoredHttpServerUris", monitoredHttpServerUris)
+      .put("monitoredHttpClientUris", monitoredHttpClientUris)
+      .put("monitoredEventBusHandlers", monitoredEventBusHandlers)
+      .put("configPath", "the_config_file");
 
     DropwizardMetricsOptions options = new DropwizardMetricsOptions(config);
 
@@ -156,19 +156,19 @@ public class MetricsOptionsTest extends VertxTestBase {
 
   @Test
   public void testInvalidAndEmptyMonitoredEntries() throws Exception {
-    JsonArray monitoredServerUris = new JsonArray()
-        .add(new JsonObject().put("value", "/test/server/1").put("type", "EQUALS"));
+    JsonArray monitoredHttpServerUris = new JsonArray()
+      .add(new JsonObject().put("value", "/test/server/1").put("type", "EQUALS"));
 
-    JsonArray monitoredClientUris = new JsonArray()
-        .add(new JsonObject().put("value", "/test/client/1").put("type", "EQUALS"))
-        .add("Just a string");
+    JsonArray monitoredHttpClientUris = new JsonArray()
+      .add(new JsonObject().put("value", "/test/client/1").put("type", "EQUALS"))
+      .add("Just a string");
 
     JsonObject config = new JsonObject()
-        .put("registryName", "testRegistry")
-        .put("jmxEnabled", true)
-        .put("jmxDomain", "testJmxDomain")
-        .put("monitoredServerUris", monitoredServerUris)
-        .put("monitoredClientUris", monitoredClientUris);
+      .put("registryName", "testRegistry")
+      .put("jmxEnabled", true)
+      .put("jmxDomain", "testJmxDomain")
+      .put("monitoredHttpServerUris", monitoredHttpServerUris)
+      .put("monitoredHttpClientUris", monitoredHttpClientUris);
 
     DropwizardMetricsOptions options = new DropwizardMetricsOptions(config);
 

--- a/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
@@ -137,11 +137,110 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
   public void testFromJson() throws Exception {
     VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(vertx, new VertxOptions(
-      new JsonObject().put("metricsOptions", new JsonObject().put("enabled", true).put("monitoredHttpClientUris", new JsonArray().add(new JsonObject().put("value", "http://www.foo.com"))))
+      new JsonObject().put("metricsOptions", new JsonObject()
+        .put("enabled", true)
+        .put("monitoredEventBusHandlers", new JsonArray()
+          .add(new JsonObject().put("value", "foo")))
+        .put("monitoredHttpServerUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.bar.com")))
+        .put("monitoredHttpClientUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.baz.com")))
+        .put("monitoredHttpClientEndpoints", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.foobar.com"))))
     ));
     DropwizardMetricsOptions options = metrics.getOptions();
+
+    assertEquals(1, options.getMonitoredEventBusHandlers().size());
+    assertEquals("foo", options.getMonitoredEventBusHandlers().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredEventBusHandlers().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpServerUris().size());
+    assertEquals("http://www.bar.com", options.getMonitoredHttpServerUris().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpServerUris().get(0).getType());
+
     assertEquals(1, options.getMonitoredHttpClientUris().size());
-    assertEquals("http://www.foo.com", options.getMonitoredHttpClientUris().get(0).getValue());
+    assertEquals("http://www.baz.com", options.getMonitoredHttpClientUris().get(0).getValue());
     assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientUris().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpClientEndpoint().size());
+    assertEquals("http://www.foobar.com", options.getMonitoredHttpClientEndpoint().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientEndpoint().get(0).getType());
+  }
+
+  @Test
+  public void testFromDeprecatedJson() throws Exception {
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(vertx, new VertxOptions(
+      new JsonObject().put("metricsOptions", new JsonObject()
+        .put("enabled", true)
+        .put("monitoredHandlers", new JsonArray()
+          .add(new JsonObject().put("value", "foo")))
+        .put("monitoredServerUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.bar.com")))
+        .put("monitoredClientUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.baz.com")))
+        .put("monitoredClientEndpoints", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.foobar.com"))))
+    ));
+    DropwizardMetricsOptions options = metrics.getOptions();
+
+    assertEquals(1, options.getMonitoredEventBusHandlers().size());
+    assertEquals("foo", options.getMonitoredEventBusHandlers().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredEventBusHandlers().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpServerUris().size());
+    assertEquals("http://www.bar.com", options.getMonitoredHttpServerUris().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpServerUris().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpClientUris().size());
+    assertEquals("http://www.baz.com", options.getMonitoredHttpClientUris().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientUris().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpClientEndpoint().size());
+    assertEquals("http://www.foobar.com", options.getMonitoredHttpClientEndpoint().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientEndpoint().get(0).getType());
+  }
+
+  @Test
+  public void testFromJsonMixed() throws Exception {
+    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(vertx, new VertxOptions(
+      new JsonObject().put("metricsOptions", new JsonObject()
+        .put("enabled", true)
+        .put("monitoredEventBusHandlers", new JsonArray()
+          .add(new JsonObject().put("value", "foo")))
+        .put("monitoredHttpServerUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.bar.com")))
+        .put("monitoredHttpClientUris", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.baz.com")))
+        .put("monitoredHttpClientEndpoints", new JsonArray()
+          .add(new JsonObject().put("value", "http://www.foobar.com")))
+        // Deprecated fields
+        .put("monitoredHandlers", new JsonArray()
+          .add(new JsonObject().put("value", "will be ignored")))
+        .put("monitoredServerUris", new JsonArray()
+          .add(new JsonObject().put("value", "will be ignored")))
+        .put("monitoredClientUris", new JsonArray()
+          .add(new JsonObject().put("value", "will be ignored")))
+        .put("monitoredClientEndpoints", new JsonArray()
+          .add(new JsonObject().put("value", "will be ignored"))))
+    ));
+    DropwizardMetricsOptions options = metrics.getOptions();
+
+    assertEquals(1, options.getMonitoredEventBusHandlers().size());
+    assertEquals("foo", options.getMonitoredEventBusHandlers().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredEventBusHandlers().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpServerUris().size());
+    assertEquals("http://www.bar.com", options.getMonitoredHttpServerUris().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpServerUris().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpClientUris().size());
+    assertEquals("http://www.baz.com", options.getMonitoredHttpClientUris().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientUris().get(0).getType());
+
+    assertEquals(1, options.getMonitoredHttpClientEndpoint().size());
+    assertEquals("http://www.foobar.com", options.getMonitoredHttpClientEndpoint().get(0).getValue());
+    assertEquals(MatchType.EQUALS, options.getMonitoredHttpClientEndpoint().get(0).getType());
   }
 }

--- a/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
@@ -51,7 +51,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
   public void testLoadingFromFileFromJson() throws Exception {
     String filePath = ClassLoader.getSystemResource("test_metrics_config.json").getFile();
     VertxOptions vertxOptions = new VertxOptions(new JsonObject().
-        put("metricsOptions", new JsonObject().put("configPath", filePath)));
+      put("metricsOptions", new JsonObject().put("configPath", filePath)));
 
     // Verify our jmx domain isn't there already, just in case.
     assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
@@ -101,8 +101,8 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
   @Test
   public void testWithNoConfigFile() throws Exception {
     DropwizardMetricsOptions dmo = new DropwizardMetricsOptions()
-        .setJmxEnabled(true)
-        .setJmxDomain("non-file-jmx");
+      .setJmxEnabled(true)
+      .setJmxDomain("non-file-jmx");
     VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
 
     VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
@@ -119,9 +119,9 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
     String filePath = "/i/am/not/here/missingfile.json";
 
     DropwizardMetricsOptions dmo = new DropwizardMetricsOptions()
-        .setJmxEnabled(true)
-        .setJmxDomain("non-file-jmx")
-        .setConfigPath(filePath);
+      .setJmxEnabled(true)
+      .setJmxDomain("non-file-jmx")
+      .setConfigPath(filePath);
     VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
 
     VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
@@ -137,7 +137,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
   public void testFromJson() throws Exception {
     VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(vertx, new VertxOptions(
-        new JsonObject().put("metricsOptions", new JsonObject().put("enabled", true).put("monitoredClientUris", new JsonArray().add(new JsonObject().put("value", "http://www.foo.com"))))
+      new JsonObject().put("metricsOptions", new JsonObject().put("enabled", true).put("monitoredHttpClientUris", new JsonArray().add(new JsonObject().put("value", "http://www.foo.com"))))
     ));
     DropwizardMetricsOptions options = metrics.getOptions();
     assertEquals(1, options.getMonitoredHttpClientUris().size());


### PR DESCRIPTION
For some reason, we used different names for option fields in JSON format. This was confusing for the user.	