### PR TITLE
Fixes io.vertx.ext.dropwizard.MetricsTest.testEventBusMetricsHandlerRegexMatchWithIdentifier

### DIFF
--- a/src/test/java/io/vertx/ext/dropwizard/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/MetricsTest.java
@@ -885,11 +885,11 @@ public class MetricsTest extends MetricsTestBase {
     CountDownLatch allHandlersLatch = new CountDownLatch(3);
 
     vertx.eventBus().consumer("user:1", msg -> {
-      allHandlersLatch.countDown();
+      vertx.runOnContext(v -> allHandlersLatch.countDown());
     });
 
     vertx.eventBus().consumer("user:2", msg -> {
-      allHandlersLatch.countDown();
+      vertx.runOnContext(v -> allHandlersLatch.countDown());
     });
     vertx.eventBus().send("user:1", "whatever");
     vertx.eventBus().send("user:1", "whatever one more time");


### PR DESCRIPTION
```
java.lang.AssertionError: null (count) expected:<3> but was:<2>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at io.vertx.test.core.AsyncTestBase.assertEquals(AsyncTestBase.java:431)
	at io.vertx.ext.dropwizard.MetricsTest.assertCount(MetricsTest.java:1299)
	at io.vertx.ext.dropwizard.MetricsTest.testEventBusMetricsHandlerRegexMatchWithIdentifier(MetricsTest.java:902)
```

`allHandlersLatch` should be updated after the consumer handler is done otherwise metrics might not be updated in time.