### PR TITLE
Add DropWizardMetricsOptions method to specify custom metricRegistry

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -54,6 +54,10 @@ Add an monitored http server uri.
 +++
 Set the name used for registering the metrics in the Dropwizard shared registry.
 +++
+|[[metricRegistry]]`metricRegistry`|`MetricRegistry`|
++++
+Set an optional metric registry used instead of the Dropwizard shared registry.
++++
 |===
 
 [[Match]]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -542,7 +542,7 @@ so you can retrieve this registry and use according to your needs.
 
 == Using already existing Dropwizard Registry
 Optionally, it is possible to utilize already existing https://dropwizard.github.io/metrics/3.1.0/getting-started/#the-registry[Dropwizard Registry].
-In order to do so pass MetricRegistry instance as parameter for setMetricRegistry function in VertxOptions object.
+In order to do so pass `MetricRegistry` instance as parameter for `setMetricRegistry` function in `VertxOptions` object.
 
 [source,java]
 ----

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -540,6 +540,19 @@ so you can retrieve this registry and use according to your needs.
 {@link examples.MetricsExamples#getRegistry()}}
 ----
 
+== Using already existing Dropwizard Registry
+Optionally, it is possible to utilize already existing https://dropwizard.github.io/metrics/3.1.0/getting-started/#the-registry[Dropwizard Registry].
+In order to do so pass MetricRegistry instance as parameter for setMetricRegistry function in VertxOptions object.
+
+[source,java]
+----
+MetricRegistry metricRegistry = new MetricRegistry();
+VertxOptions options = new VertxOptions().setMetricsOptions(
+    new DropwizardMetricsOptions().setEnabled(true).setMetricRegistry(metricRegistry)
+);
+Vertx vertx = Vertx.vertx(options);
+----
+
 == Using Jolokia and Hawtio
 
 https://jolokia.org/[Jolokia] is a JMX-HTTP bridge giving an alternative to JSR-160 connectors. It is an agent based

--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.dropwizard;
 
+import com.codahale.metrics.MetricRegistry;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -70,6 +71,7 @@ public class DropwizardMetricsOptions extends MetricsOptions {
   private List<Match> monitoredHttpClientEndpoints;
   private String configPath;
   private String baseName;
+  private MetricRegistry metricRegistry;
 
   /**
    * Default constructor
@@ -111,6 +113,7 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     monitoredHttpServerUris = new ArrayList<>(other.monitoredHttpServerUris);
     monitoredHttpClientUris = new ArrayList<>(other.monitoredHttpClientUris);
     monitoredHttpClientEndpoints = new ArrayList<>(other.monitoredHttpClientEndpoints);
+    metricRegistry = other.getMetricRegistry();
   }
 
   /**
@@ -337,5 +340,25 @@ public class DropwizardMetricsOptions extends MetricsOptions {
    */
   public String getBaseName() {
     return baseName;
+  }
+
+  /**
+   * An optional metric registry used instead of the Dropwizard shared registry.
+   *
+   * @return the metricRegistry
+   */
+  public MetricRegistry getMetricRegistry() {
+    return metricRegistry;
+  }
+
+  /**
+   * Set the optional metric registry used instead of the Dropwizard shared registry.
+   *
+   * @param metricRegistry the metricRegistry
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DropwizardMetricsOptions setMetricRegistry(MetricRegistry metricRegistry) {
+    this.metricRegistry = metricRegistry;
+    return this;
   }
 }

--- a/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsFactoryImpl.java
+++ b/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsFactoryImpl.java
@@ -51,7 +51,7 @@ public class VertxMetricsFactoryImpl implements VertxMetricsFactory {
     } else {
       metricsOptions = new DropwizardMetricsOptions(baseOptions.toJson());
     }
-    MetricRegistry registry = new MetricRegistry();
+    MetricRegistry registry = metricsOptions.getMetricRegistry() != null ? metricsOptions.getMetricRegistry() : new MetricRegistry();
     boolean shutdown = true;
     if (metricsOptions.getRegistryName() != null) {
       MetricRegistry other = SharedMetricRegistries.add(metricsOptions.getRegistryName(), registry);

--- a/src/test/java/io/vertx/ext/dropwizard/MetricRegistryTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/MetricRegistryTest.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.dropwizard;
+
+import com.codahale.metrics.MetricRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author <a href="mailto:bartosz.jk.wozniak@gmail.com">Bartosz Woźniak</a>
+ */
+public class MetricRegistryTest {
+
+  private VertxOptions getOptionsWithoutSetMetricRegistry() {
+    return new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions().setEnabled(true));
+  }
+
+  private VertxOptions getOptionsWithSetMetricRegistry() {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    return new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions().setEnabled(true).setMetricRegistry(metricRegistry));
+  }
+
+  @Test
+  public void testVertxWithoutSetMetricRegistryOption() {
+    Vertx vertx = Vertx.vertx(getOptionsWithoutSetMetricRegistry());
+    assertNotNull(vertx);
+    vertx.close();
+  }
+
+  @Test
+  public void testMetricServiceWithoutSetMetricRegistryOption(){
+    Vertx vertx = Vertx.vertx(getOptionsWithoutSetMetricRegistry());
+    MetricsService metricsService = MetricsService.create(vertx);
+    assertTrue(metricsService.metricsNames().size()>0);
+  }
+
+  @Test
+  public void testVertxWithSetMetricRegistryOption() {
+    Vertx vertx = Vertx.vertx(getOptionsWithSetMetricRegistry());
+    assertNotNull(vertx);
+    vertx.close();
+  }
+
+  @Test
+  public void testMetricServiceWithSetMetricRegistryOption(){
+    Vertx vertx = Vertx.vertx(getOptionsWithSetMetricRegistry());
+    MetricsService metricsService = MetricsService.create(vertx);
+    assertTrue(metricsService.metricsNames().size()>0);
+  }
+}


### PR DESCRIPTION
This change allows to use already existing metric registry for vertx metrics, e.g. the one used by spring boot's actuator.