### PR TITLE
HttpMetricsImpl NPE prevention - metric is not guaranteed to be present

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/impl/HttpMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/dropwizard/impl/HttpMetricsImpl.java
@@ -73,7 +73,7 @@ abstract class HttpMetricsImpl extends TCPMetricsImpl {
    * @param matcher the Matcher instance
    */
   protected long end(HttpRequestMetric metric, int statusCode, Matcher matcher) {
-    if (closed) {
+    if (closed || metric == null) {
       return 0;
     }
     String match = null;


### PR DESCRIPTION
Vertx version: 3.9.1
One of our services using Vertx as core framework is experiencing NPE during startup with the following stacktrace.
There might occur a rare situation, that will result in null metric object on connection being closed.

`java.lang.NullPointerException: null
	at io.vertx.ext.dropwizard.impl.HttpMetricsImpl.end(HttpMetricsImpl.java:79)
	at io.vertx.ext.dropwizard.impl.HttpClientMetricsImpl.requestReset(HttpClientMetricsImpl.java:128)
	at io.vertx.ext.dropwizard.impl.HttpClientMetricsImpl.requestReset(HttpClientMetricsImpl.java:34)
	at io.vertx.core.http.impl.Http2ClientConnection$Http2ClientStream.handleClose(Http2ClientConnection.java:295)
	at io.vertx.core.http.impl.Http2ConnectionBase.lambda$onStreamClosed$2(Http2ConnectionBase.java:162)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:229)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:221)
	at io.vertx.core.http.impl.Http2ConnectionBase.onStreamClosed(Http2ConnectionBase.java:162)
	at io.vertx.core.http.impl.Http2ClientConnection.onStreamClosed(Http2ClientConnection.java:96)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.onStreamClosed(VertxHttp2ConnectionHandler.java:164)
	at io.netty.handler.codec.http2.DefaultHttp2Connection.notifyClosed(DefaultHttp2Connection.java:356)
	at io.netty.handler.codec.http2.DefaultHttp2Connection$ActiveStreams.removeFromActiveStreams(DefaultHttp2Connection.java:1000)
	at io.netty.handler.codec.http2.DefaultHttp2Connection$ActiveStreams.deactivate(DefaultHttp2Connection.java:956)
	at io.netty.handler.codec.http2.DefaultHttp2Connection$DefaultStream.close(DefaultHttp2Connection.java:512)
	at io.netty.handler.codec.http2.DefaultHttp2Connection$DefaultStream.close(DefaultHttp2Connection.java:518)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.closeStream(Http2ConnectionHandler.java:613)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.processRstStreamWriteResult(Http2ConnectionHandler.java:885)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.resetStream(Http2ConnectionHandler.java:804)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.resetStream(Http2ConnectionHandler.java:777)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder.writeRstStream(DefaultHttp2ConnectionEncoder.java:286)
	at io.netty.handler.codec.http2.DecoratingHttp2FrameWriter.writeRstStream(DecoratingHttp2FrameWriter.java:65)
	at io.netty.handler.codec.http2.Http2ControlFrameLimitEncoder.writeRstStream(Http2ControlFrameLimitEncoder.java:85)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler._writeReset(VertxHttp2ConnectionHandler.java:297)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.writeReset(VertxHttp2ConnectionHandler.java:288)
	at io.vertx.core.http.impl.VertxHttp2Stream.writeReset(VertxHttp2Stream.java:158)
	at io.vertx.core.http.impl.Http2ClientConnection$Http2ClientStream.reset(Http2ClientConnection.java:472)
	at io.vertx.core.http.impl.HttpClientRequestImpl.lambda$connect$7(HttpClientRequestImpl.java:463)
	at io.vertx.core.http.impl.Http2ClientConnection.createStream(Http2ClientConnection.java:126)
	at io.vertx.core.http.impl.HttpClientImpl.lambda$getConnectionForRequest$4(HttpClientImpl.java:1041)
	at io.vertx.core.http.impl.ConnectionManager.lambda$getConnection$7(ConnectionManager.java:158)
	at io.vertx.core.http.impl.pool.Pool.connectSucceeded(Pool.java:380)
	at io.vertx.core.http.impl.pool.Pool.access$500(Pool.java:89)
	at io.vertx.core.http.impl.pool.Pool$Holder.lambda$connect$0(Pool.java:127)
	at io.vertx.core.impl.FutureImpl.dispatch(FutureImpl.java:105)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:150)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
	at io.vertx.core.http.impl.HttpChannelConnector.lambda$http2Connected$5(HttpChannelConnector.java:241)
	at io.vertx.core.http.impl.Http2ClientConnection.lambda$createHttp2ConnectionHandler$4(Http2ClientConnection.java:540)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.onSettingsRead(VertxHttp2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onSettingsRead(Http2FrameListenerDecorator.java:69)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onSettingsRead(DefaultHttp2ConnectionDecoder.java:479)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onSettingsRead(DefaultHttp2ConnectionDecoder.java:702)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readSettingsFrame(DefaultHttp2FrameReader.java:542)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:263)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:160)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:174)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:63)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:378)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:242)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:438)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:501)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:440)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.channelRead(VertxHttp2ConnectionHandler.java:418)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1518)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1267)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1314)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:501)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:440)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:792)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:475)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:832)
`