### PR TITLE
Deprecate DropwizardMetricsOptions#setMetricsRegistry(MetricRegistry)

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/dropwizard/DropwizardMetricsOptions.java
@@ -22,6 +22,7 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.spi.VertxMetricsFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -356,21 +357,18 @@ public class DropwizardMetricsOptions extends MetricsOptions {
     return baseName;
   }
 
-  /**
-   * An optional metric registry used instead of the Dropwizard shared registry.
-   *
-   * @return the metricRegistry
-   */
+  @Deprecated
   public MetricRegistry getMetricRegistry() {
     return metricRegistry;
   }
 
   /**
-   * Set the optional metric registry used instead of the Dropwizard shared registry.
+   * Deprecated, instead use a {@link io.vertx.core.VertxBuilder#withMetrics(VertxMetricsFactory)} setting
+   * an instance build using {@link DropwizardVertxMetricsFactory(MetricRegistry)}.
    *
-   * @param metricRegistry the metricRegistry
-   * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link DropwizardVertxMetricsFactory(MetricRegistry}
    */
+  @Deprecated
   public DropwizardMetricsOptions setMetricRegistry(MetricRegistry metricRegistry) {
     this.metricRegistry = metricRegistry;
     return this;

--- a/src/main/java/io/vertx/ext/dropwizard/impl/AbstractMetrics.java
+++ b/src/main/java/io/vertx/ext/dropwizard/impl/AbstractMetrics.java
@@ -91,7 +91,7 @@ public abstract class AbstractMetrics implements Metrics {
     return name.substring(baseName.length() + 1);
   }
 
-  protected MetricRegistry registry() {
+  public final MetricRegistry registry() {
     return registry;
   }
 

--- a/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsImpl.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
+public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
 
   private final DropwizardMetricsOptions options;
   private Handler<Void> doneHandler;
@@ -47,7 +47,7 @@ class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   private final Map<String, HttpClientReporter> clientReporters = new ConcurrentHashMap<>();
   private final Map<String, DropwizardClientMetrics> clientMetrics = new HashMap<>();
 
-  VertxMetricsImpl(MetricRegistry registry, boolean shutdown, VertxOptions options, DropwizardMetricsOptions metricsOptions, String baseName) {
+  public VertxMetricsImpl(MetricRegistry registry, boolean shutdown, VertxOptions options, DropwizardMetricsOptions metricsOptions, String baseName) {
     super(registry, baseName);
 
     this.options = metricsOptions;
@@ -181,8 +181,7 @@ class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     return true;
   }
 
-  void setDoneHandler(Handler<Void> handler) {
+  public void setDoneHandler(Handler<Void> handler) {
     this.doneHandler = handler;
   }
-
 }

--- a/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -14,4 +14,4 @@
 #  You may elect to redistribute this code under either of these licenses.
 #
 
-io.vertx.ext.dropwizard.impl.VertxMetricsFactoryImpl
+io.vertx.ext.dropwizard.DropwizardVertxMetricsFactory

--- a/src/test/java/io/vertx/ext/dropwizard/MetricRegistryTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/MetricRegistryTest.java
@@ -3,9 +3,11 @@ package io.vertx.ext.dropwizard;
 import com.codahale.metrics.MetricRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.ext.dropwizard.impl.VertxMetricsImpl;
 import org.junit.Test;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -15,11 +17,6 @@ public class MetricRegistryTest {
 
   private VertxOptions getOptionsWithoutSetMetricRegistry() {
     return new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions().setEnabled(true));
-  }
-
-  private VertxOptions getOptionsWithSetMetricRegistry() {
-    MetricRegistry metricRegistry = new MetricRegistry();
-    return new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions().setEnabled(true).setMetricRegistry(metricRegistry));
   }
 
   @Test
@@ -38,15 +35,32 @@ public class MetricRegistryTest {
 
   @Test
   public void testVertxWithSetMetricRegistryOption() {
-    Vertx vertx = Vertx.vertx(getOptionsWithSetMetricRegistry());
-    assertNotNull(vertx);
-    vertx.close();
+    MetricRegistry metricRegistry = new MetricRegistry();
+    Vertx vertx = Vertx.builder()
+      .with(getOptionsWithoutSetMetricRegistry())
+      .withMetrics(new DropwizardVertxMetricsFactory(metricRegistry))
+      .build();
+    try {
+      assertNotNull(vertx);
+      VertxMetricsImpl metrics = (VertxMetricsImpl) ((VertxInternal)vertx).metricsSPI();
+      assertSame(metricRegistry, metrics.registry());
+    } finally {
+      vertx.close();
+    }
   }
 
   @Test
   public void testMetricServiceWithSetMetricRegistryOption(){
-    Vertx vertx = Vertx.vertx(getOptionsWithSetMetricRegistry());
-    MetricsService metricsService = MetricsService.create(vertx);
-    assertTrue(metricsService.metricsNames().size()>0);
+    MetricRegistry metricRegistry = new MetricRegistry();
+    Vertx vertx = Vertx.builder()
+      .with(getOptionsWithoutSetMetricRegistry())
+      .withMetrics(new DropwizardVertxMetricsFactory(metricRegistry))
+      .build();
+    try {
+      MetricsService metricsService = MetricsService.create(vertx);
+      assertTrue(metricsService.metricsNames().size()>0);
+    } finally {
+      vertx.close();
+    }
   }
 }

--- a/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/impl/VertxMetricFactoryImplTest.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
+import io.vertx.ext.dropwizard.DropwizardVertxMetricsFactory;
 import io.vertx.ext.dropwizard.MatchType;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.After;
@@ -38,7 +39,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
     // Verify our jmx domain isn't there already, just in case.
     assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -56,7 +57,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
     // Verify our jmx domain isn't there already, just in case.
     assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -74,7 +75,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
     // Verify our jmx domain isn't there already, just in case.
     assertFalse(Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains()).contains("test-jmx-domain"));
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -89,7 +90,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
     DropwizardMetricsOptions dmo = new DropwizardMetricsOptions().setConfigPath(filePath);
     VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -105,7 +106,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
       .setJmxDomain("non-file-jmx");
     VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -124,7 +125,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
       .setConfigPath(filePath);
     VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(dmo);
 
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     metrics = vmfi.metrics(vertxOptions);
 
     List<String> jmxDomains = Arrays.asList(ManagementFactory.getPlatformMBeanServer().getDomains());
@@ -135,7 +136,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
 
   @Test
   public void testFromJson() throws Exception {
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(new VertxOptions(
       new JsonObject().put("metricsOptions", new JsonObject()
         .put("enabled", true)
@@ -169,7 +170,7 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
 
   @Test
   public void testFromJsonMixed() throws Exception {
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(new VertxOptions(
       new JsonObject().put("metricsOptions", new JsonObject()
         .put("enabled", true)
@@ -212,14 +213,14 @@ public class VertxMetricFactoryImplTest extends VertxTestBase {
 
   @Test
   public void testDefaultBaseName() {
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions()));
     assertEquals("vertx", metrics.baseName());
   }
 
   @Test
   public void testOverrideBaseName() {
-    VertxMetricsFactoryImpl vmfi = new VertxMetricsFactoryImpl();
+    DropwizardVertxMetricsFactory vmfi = new DropwizardVertxMetricsFactory();
     VertxMetricsImpl metrics = (VertxMetricsImpl) vmfi.metrics(new VertxOptions().setMetricsOptions(new DropwizardMetricsOptions().setBaseName("Foo")));
     assertEquals("Foo", metrics.baseName());
   }


### PR DESCRIPTION
In favor of `DropwizardMetricsFactory(MetricRegistry)` + `VertxBuilder#withMetrics`
