### PR TITLE
fix: safe default init VertxMetricsImpl.httpClientMonitoredEndpoints

### DIFF
--- a/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/dropwizard/impl/VertxMetricsImpl.java
@@ -57,7 +57,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     if (monitoredHttpClientEndpoint != null) {
       monitoredHttpClientMatcher = new Matcher(monitoredHttpClientEndpoint);
     } else {
-      monitoredHttpClientMatcher = null;
+      monitoredHttpClientMatcher = new Matcher(List.of(new Match().setValue(".*")));
     }
 
     this.options = metricsOptions;

--- a/src/test/java/io/vertx/ext/dropwizard/tests/impl/VertxMetricsImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/impl/VertxMetricsImplTest.java
@@ -1,7 +1,10 @@
 package io.vertx.ext.dropwizard.tests.impl;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.codahale.metrics.MetricRegistry;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
 import io.vertx.ext.dropwizard.impl.VertxMetricsImpl;
 import org.junit.Test;
@@ -12,10 +15,11 @@ import org.junit.Test;
 public class VertxMetricsImplTest {
 
   @Test(expected = Test.None.class)
-  public void testCreatePoolMetrics() {
+  public void testCreatePoolMetricsShouldNotThrowNPE() {
     VertxMetricsImpl vmi = new VertxMetricsImpl(new MetricRegistry(), false,
       new VertxOptions(), new DropwizardMetricsOptions(), "baseName");
 
-    vmi.createPoolMetrics("http", "poolName", 1);
+    PoolMetrics actual = vmi.createPoolMetrics("http", "poolName", 1);
+    assertNotNull(actual);
   }
 }

--- a/src/test/java/io/vertx/ext/dropwizard/tests/impl/VertxMetricsImplTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/impl/VertxMetricsImplTest.java
@@ -1,0 +1,21 @@
+package io.vertx.ext.dropwizard.tests.impl;
+
+import com.codahale.metrics.MetricRegistry;
+import io.vertx.core.VertxOptions;
+import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
+import io.vertx.ext.dropwizard.impl.VertxMetricsImpl;
+import org.junit.Test;
+
+/**
+ * @author Siarhei.Bahdanchuk Date: 29.07.2025
+ */
+public class VertxMetricsImplTest {
+
+  @Test(expected = Test.None.class)
+  public void testCreatePoolMetrics() {
+    VertxMetricsImpl vmi = new VertxMetricsImpl(new MetricRegistry(), false,
+      new VertxOptions(), new DropwizardMetricsOptions(), "baseName");
+
+    vmi.createPoolMetrics("http", "poolName", 1);
+  }
+}


### PR DESCRIPTION
Motivation:

When migrating from vertx4 to vertx5 got exception
```
java.lang.NullPointerException: Cannot invoke "io.vertx.ext.dropwizard.impl.Matcher.matches(String)" because "this.httpClientMonitoredEndpoints" is null
	at io.vertx.ext.dropwizard.impl.VertxMetricsImpl.createPoolMetrics(VertxMetricsImpl.java:166)
	at io.vertx.core.http.impl.HttpClientImpl.lambda$httpEndpointProvider$1(HttpClientImpl.java:133)
	at io.vertx.core.internal.resource.ResourceManager.lambda$withResourceAsync$5(ResourceManager.java:126)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.vertx.core.internal.resource.ResourceManager.withResourceAsync(ResourceManager.java:125)
	at io.vertx.core.http.impl.HttpClientImpl.doRequest(HttpClientImpl.java:372)
	at io.vertx.core.http.impl.HttpClientImpl.doRequest(HttpClientImpl.java:320)
	at io.vertx.core.http.impl.HttpClientImpl.request(HttpClientImpl.java:276)
	at io.vertx.core.http.impl.CleanableHttpClient.request(CleanableHttpClient.java:61)
```
To fix this one can add config to the vertx
        ```
.setMetricsOptions(new DropwizardMetricsOptions()
                .setEnabled(true)
                .addMonitoredHttpClientEndpoint(new Match().setValue(".*")));
vertx = Vertx.vertx(vertxOptions);
```
But the initial vertx configuration is impossible and it is possible to get NPE on runtime randomly

To prevent this I propose safe default init of the VertxMetrics.Impl.httpClientMonitoredEndpoints with a wildcard pattern
