### PR TITLE
Fix build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,9 @@
   ~      http://www.opensource.org/licenses/apache2.0.php
   ~
   ~  You may elect to redistribute this code under either of these licenses.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -179,5 +181,92 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-native-quic</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-native-quic</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>osx</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <classifier>osx-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <classifier>osx-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-native-quic</artifactId>
+          <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-native-quic</artifactId>
+          <classifier>osx-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-native-quic</artifactId>
+          <classifier>windows-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
@@ -44,7 +44,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
@@ -631,7 +630,10 @@ public class MetricsTest extends MetricsTestBase {
     });
     server.listen(8080, "localhost").await();
     HttpClientAgent client = vertx.createHttpClient(
-      new HttpClientConfig().setVersions(List.of(HttpVersion.HTTP_3)),
+      new HttpClientConfig()
+        .setVersions(List.of(HttpVersion.HTTP_3))
+        .setSsl(true)
+        .setVerifyHost(false),
       new ClientSSLOptions().setTrustAll(true));
     Buffer resp = client
       .request(HttpMethod.GET, 8080, "localhost", "/")
@@ -659,7 +661,9 @@ public class MetricsTest extends MetricsTestBase {
     server.listen(8080, "localhost").await();
     HttpClientConfig clientCfg = new HttpClientConfig();
     HttpClientAgent client = vertx.createHttpClient(clientCfg
-      .setVersions(List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_3)), new ClientSSLOptions().setTrustAll(true));
+      .setVersions(List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_3))
+      .setSsl(true)
+      .setVerifyHost(false), new ClientSSLOptions().setTrustAll(true));
     for (HttpVersion version : List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_3)) {
       RequestOptions options = new RequestOptions()
         .setPort(8080)

--- a/src/test/java/io/vertx/ext/dropwizard/tests/QuicMetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/QuicMetricsTest.java
@@ -15,7 +15,6 @@
  */
 package io.vertx.ext.dropwizard.tests;
 
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.ext.dropwizard.MetricsService;
 import io.vertx.test.core.LinuxOrOsx;
@@ -24,8 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(LinuxOrOsx.class)
 public class QuicMetricsTest extends MetricsTestBase {
@@ -39,8 +36,12 @@ public class QuicMetricsTest extends MetricsTestBase {
     });
     server.listen(1234, "localhost").await();
 
-    QuicClient client = vertx.createQuicClient(new QuicClientConfig(), new ClientSSLOptions()
-      .setTrustAll(true).setApplicationLayerProtocols(List.of("test-protocol")));
+    QuicClient client = vertx.createQuicClient(
+      new QuicClientConfig(),
+      new ClientSSLOptions()
+        .setTrustAll(true)
+        .setHostnameVerificationAlgorithm("")
+        .setApplicationLayerProtocols(List.of("test-protocol")));
     MetricsService metricsService = MetricsService.create(vertx);
     QuicConnection connection = client.connect(SocketAddress.inetSocketAddress(1234, "localhost")).await();
     QuicStream stream = connection.openStream().await();


### PR DESCRIPTION
Follows-up on changes in Vert.x Core

Add dependencies on netty-codec-native-quic for Linux, macOS, and Windows platforms.

Adapt to Vert.x core API changes where SSL is now implicit when a non-null ServerSSLOptions is provided.
Update HttpClientConfig to explicitly call setSsl(true) and setVerifyHost(false) for test configurations.

Disable hostname verification for QUIC test certificates to accommodate self-signed certificate usage.