### PR TITLE
Fix MetricsTest for cleanable clients

### DIFF
--- a/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
@@ -382,6 +382,7 @@ public class MetricsTest extends MetricsTestBase {
     CountDownLatch latch = new CountDownLatch(requests);
 
     HttpClientAgent client = vertx.createHttpClient(new HttpClientOptions());
+    String clientBaseName = metricsService.getBaseName(client);
     HttpServer server = vertx.createHttpServer(new HttpServerOptions().setHost("localhost").setPort(8081)).requestHandler(req -> {
       req.response().end();
     });
@@ -410,7 +411,11 @@ public class MetricsTest extends MetricsTestBase {
       JsonObject metrics = metricsService.getMetricsSnapshot(server);
       return metrics != null && metrics.isEmpty();
     });
-    assertWaitUntil(() -> metricsService.getMetricsSnapshot(client).getJsonObject("connections.max-pool-size") == null);
+    assertWaitUntil(() -> {
+      // Use the clientBaseName because metricsService.getMetricsSnapshot(client) could throw an ISE
+      // If the cleanable client is no longer able to reach the actual client
+      return metricsService.getMetricsSnapshot(clientBaseName).getJsonObject("connections.max-pool-size") == null;
+    });
   }
 
   @Test
@@ -772,6 +777,7 @@ public class MetricsTest extends MetricsTestBase {
     CountDownLatch latch = new CountDownLatch(requests);
 
     NetClient client = vertx.createNetClient(new NetClientOptions());
+    String clientBaseName = metricsService.getBaseName(client);
     NetServer server = vertx.createNetServer(new NetServerOptions().setHost("localhost").setPort(1235).setReceiveBufferSize(50)).connectHandler(socket -> {
       socket.handler(buff -> latch.countDown());
     });
@@ -793,7 +799,9 @@ public class MetricsTest extends MetricsTestBase {
       return metrics != null && metrics.isEmpty();
     });
 
-    JsonObject metrics = metricsService.getMetricsSnapshot(client);
+    // Use the clientBaseName because metricsService.getMetricsSnapshot(client) could throw an ISE
+    // If the cleanable client is no longer able to reach the actual client
+    JsonObject metrics = metricsService.getMetricsSnapshot(clientBaseName);
     assertNotNull(metrics);
     assertTrue(metrics.isEmpty());
 


### PR DESCRIPTION
In CI, there was an ISE thrown:

```
Error:  io.vertx.ext.dropwizard.tests.MetricsTest.testNetMetricsOnClose -- Time elapsed: 0.012 s <<< ERROR! java.lang.IllegalStateException
	at io.vertx.core@5.1.0-SNAPSHOT/io.vertx.core.impl.CleanableObject.getOrDie(CleanableObject.java:61)
	at io.vertx.core@5.1.0-SNAPSHOT/io.vertx.core.net.impl.tcp.CleanableNetClient.getMetrics(CleanableNetClient.java:89)
	at io.vertx.metrics.dropwizard@5.1.0-SNAPSHOT/io.vertx.ext.dropwizard.impl.AbstractMetrics.unwrap(AbstractMetrics.java:48)
	at io.vertx.metrics.dropwizard@5.1.0-SNAPSHOT/io.vertx.ext.dropwizard.impl.MetricsServiceImpl.getMetricsSnapshot(MetricsServiceImpl.java:32)
	at io.vertx.metrics.dropwizard.tests/io.vertx.ext.dropwizard.tests.MetricsTest.testNetMetricsOnClose(MetricsTest.java:796)
```

This was due to the changes in https://github.com/eclipse-vertx/vert.x/pull/6109

 In this test, we can use the clientBaseName instead of the client reference. This is functionally equivalent and robust.