### PR TITLE
Fix intermittent failure in MetricsTest#testThreadPoolMetrics

### DIFF
--- a/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
@@ -1490,6 +1490,10 @@ public class MetricsTest extends MetricsTestBase {
 
     gate.countDown();
     assertTrue(done.await(20, TimeUnit.SECONDS));
+    assertWaitUntil(() -> {
+      JsonObject metric = metricsService.getMetricsSnapshot(exec).getJsonObject("usage");
+      return Long.valueOf(6L).equals(getCount(metric));
+    });
     metrics = metricsService.getMetricsSnapshot(exec);
     assertCount(metrics.getJsonObject("usage"), 6);
     assertCount(metrics.getJsonObject("queue-delay"), 6);


### PR DESCRIPTION
The usage metric (and some others) are updated by the worker thread after executing the task.

The worker thread could be parked after the task has executed but before metrics are updated. Then the done latch could be released by the EL thread and the test would fail.