### PR TITLE
Add tests for InstantThroughput sliding-window reset behavior

### DIFF
--- a/src/test/java/io/vertx/ext/dropwizard/tests/InstantThroughputTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/InstantThroughputTest.java
@@ -22,4 +22,70 @@ public class InstantThroughputTest {
     Thread.sleep(1000);
     assertEquals(0, throughput.count());
   }
+
+  @Test
+  public void testPrevCountResetAfterTwoSeconds() throws Exception {
+    InstantThroughput throughput = new InstantThroughput();
+    // Mark some items so count > 0
+    for (int i = 0; i < 50; i++) {
+      throughput.mark();
+    }
+
+    // Wait 1.5s (between 1-2s): triggers the < TWO_SECS branch -> prevCount = count (50)
+    Thread.sleep(1500);
+    // count() calls check(): prevCount=50, timestamp reset, count=0. Returns 50.
+    assertEquals(50, throughput.count());
+
+    // Wait > 2 seconds from the timestamp reset above: triggers > TWO_SECS branch
+    // prevCount is 50 > 0, so it gets reset to 0
+    Thread.sleep(2100);
+    assertEquals(0, throughput.count());
+  }
+
+  @Test
+  public void testNoResetWhenPrevCountIsZero() throws Exception {
+    InstantThroughput throughput = new InstantThroughput();
+    // Mark a few items
+    for (int i = 0; i < 5; i++) {
+      throughput.mark();
+    }
+
+    // Wait 1.5s: triggers < TWO_SECS branch -> prevCount = 5
+    Thread.sleep(1500);
+    assertEquals(5, throughput.count());
+
+    // Wait > 2s: > TWO_SECS branch, prevCount (5) > 0 -> reset to 0
+    Thread.sleep(2100);
+    assertEquals(0, throughput.count());
+
+    // Now prevCount is 0; wait > TWO_SECS again
+    // prevCount is already 0, so the > TWO_SECS branch should not change it
+    Thread.sleep(2100);
+    assertEquals(0, throughput.count());
+  }
+
+  @Test
+  public void testMarkAfterLongPause() throws Exception {
+    InstantThroughput throughput = new InstantThroughput();
+    // Mark items
+    for (int i = 0; i < 100; i++) {
+      throughput.mark();
+    }
+
+    // Wait 1.5s: triggers < TWO_SECS branch -> prevCount = 100
+    Thread.sleep(1500);
+    assertEquals(100, throughput.count());
+
+    // Wait > 2s: > TWO_SECS branch, prevCount (100) > 0 -> reset to 0
+    Thread.sleep(2100);
+    assertEquals(0, throughput.count());
+
+    // Mark new items after the long pause
+    for (int i = 0; i < 10; i++) {
+      throughput.mark();
+    }
+    // prevCount is still 0; need to wait for next check cycle to pick up new count
+    Thread.sleep(1500);
+    assertEquals(10, throughput.count());
+  }
 }


### PR DESCRIPTION
Augments `InstantThroughputTest` with three tests covering InstantThroughput's time-windowed counter: resetting prevCount to 0 after more than two seconds idle, the no-op path when prevCount is already zero, and recovery of the counter when new marks arrive after a long pause. These exercise the greater-than-TWO_SECS branch that the existing testCompute never reached.

| metric | before | after |
|---|---|---|
| mutation score | 71% | 79% |
| test methods added | n/a | 3 |

The additions are append-only (no existing test is modified) and pass against the current code. They follow the timing style of the existing `testCompute`.

---

**How this was produced**

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant. Where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant. So every added test is verified to catch a concrete edge case the suite missed before, rather than being speculative or redundant. The change is additive only (no production code modified), and the module builds green under its CI JDK.
