### PR TITLE
Fix race condition in testEventBusMetricsReplyRecipientFailure

### DIFF
--- a/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
+++ b/src/test/java/io/vertx/ext/dropwizard/tests/MetricsTest.java
@@ -1111,6 +1111,10 @@ public class MetricsTest extends MetricsTestBase {
 
     }
 
+    assertWaitUntil(() -> {
+      JsonObject metric = metricsService.getMetricsSnapshot(vertx.eventBus()).getJsonObject("messages.reply-failures");
+      return Long.valueOf(1L).equals(getCount(metric));
+    });
     assertCount(() -> metricsService.getMetricsSnapshot(vertx.eventBus()).getJsonObject("messages.reply-failures"), 1L);
     assertCount(() -> metricsService.getMetricsSnapshot(vertx.eventBus()).getJsonObject("messages.reply-failures." + ReplyFailure.RECIPIENT_FAILURE), 1L);
   }


### PR DESCRIPTION
Wait for metrics to be recorded by the event loop thread before evaluating assertions.

Prevents intermittent null pointer failures.